### PR TITLE
🔧Prevent property script execution for non-fileClass/ancestor properties

### DIFF
--- a/src/externalApi/MetadataMenuAdapter.test.ts
+++ b/src/externalApi/MetadataMenuAdapter.test.ts
@@ -186,6 +186,121 @@ describe('MetadataMenuAdapter', () => {
     });
   });
 
+  // ...existing code...
+
+  describe('getFileClassAndAncestorsFields', () => {
+    test('returns fields for fileClass and its ancestors (Map ancestors)', () => {
+      const ancestorFields = [{name: 'id'}, {name: 'created'}];
+      const bookFields = [{name: 'title'}, {name: 'author'}];
+
+      const mockFieldsMap = new Map([
+        ['default', ancestorFields],
+        ['book', bookFields]
+      ]);
+      const mockAncestorsMap = new Map([
+        ['book', ['default']]
+      ]);
+
+      mockApp.plugins.plugins['metadata-menu'] = {
+        api: {},
+        settings: {},
+        fieldIndex: {
+          fileClassesFields: mockFieldsMap,
+          fileClassesAncestors: mockAncestorsMap
+        }
+      };
+      adapter = new MetadataMenuAdapter(mockApp, settings);
+
+      const result = (adapter as any).getFileClassAndAncestorsFields('book');
+      expect(result).toEqual([
+        ...ancestorFields,
+        ...bookFields
+      ]);
+    });
+
+    test('returns fields for fileClass and its ancestors (object ancestors)', () => {
+      const ancestorFields = [{name: 'id'}];
+      const bookFields = [{name: 'title'}];
+
+      const mockFieldsMap = new Map([
+        ['default', ancestorFields],
+        ['book', bookFields]
+      ]);
+      const mockAncestorsObj = {
+        'book': ['default']
+      };
+
+      mockApp.plugins.plugins['metadata-menu'] = {
+        api: {},
+        settings: {},
+        fieldIndex: {
+          fileClassesFields: mockFieldsMap,
+          fileClassesAncestors: mockAncestorsObj
+        }
+      };
+      adapter = new MetadataMenuAdapter(mockApp, settings);
+
+      const result = (adapter as any).getFileClassAndAncestorsFields('book');
+      expect(result).toEqual([
+        ...ancestorFields,
+        ...bookFields
+      ]);
+    });
+
+    test('returns only fileClass fields if no ancestors', () => {
+      const bookFields = [{name: 'title'}];
+      const mockFieldsMap = new Map([
+        ['book', bookFields]
+      ]);
+
+      mockApp.plugins.plugins['metadata-menu'] = {
+        api: {},
+        settings: {},
+        fieldIndex: {
+          fileClassesFields: mockFieldsMap,
+          fileClassesAncestors: new Map()
+        }
+      };
+      adapter = new MetadataMenuAdapter(mockApp, settings);
+
+      const result = (adapter as any).getFileClassAndAncestorsFields('book');
+      expect(result).toEqual(bookFields);
+    });
+
+    test('throws exception if fileClass not found', () => {
+      const mockFieldsMap = new Map([
+        ['default', [{name: 'id'}]]
+      ]);
+      mockApp.plugins.plugins['metadata-menu'] = {
+        api: {},
+        settings: {},
+        fieldIndex: {
+          fileClassesFields: mockFieldsMap,
+          fileClassesAncestors: new Map()
+        }
+      };
+      adapter = new MetadataMenuAdapter(mockApp, settings);
+      const result = (adapter as any).getFileClassAndAncestorsFields('book');
+      expect(result).toEqual([]);
+    });
+
+    test('returns empty array if no fields and no ancestors', () => {
+      const mockFieldsMap = new Map();
+      mockApp.plugins.plugins['metadata-menu'] = {
+        api: {},
+        settings: {},
+        fieldIndex: {
+          fileClassesFields: mockFieldsMap,
+          fileClassesAncestors: new Map()
+        }
+      };
+      adapter = new MetadataMenuAdapter(mockApp, settings);
+
+      const result = (adapter as any).getFileClassAndAncestorsFields('book');
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('getFileClassAlias', () => {
     test('throws exception when plugin not available', () => {
       adapter = new MetadataMenuAdapter(mockApp, settings);

--- a/src/services/MetaFlowService.test.ts
+++ b/src/services/MetaFlowService.test.ts
@@ -104,6 +104,10 @@ describe('MetaFlowService', () => {
       syncFields: jest.fn().mockImplementation((frontmatter) => frontmatter),
       getFileClassFromMetadata: realMetadataMenuAdapter.getFileClassFromMetadata.bind(realMetadataMenuAdapter), // Use real implementation
       getFileClassAlias: jest.fn().mockReturnValue('fileClass'),
+      getFileClassAndAncestorsFields: jest.fn().mockReturnValue([
+        {name: 'title', type: 'string'},
+        {name: 'author', type: 'number'},
+      ])
     };
 
     mockTemplaterAdapter = {
@@ -308,10 +312,10 @@ Content here`;
       const result = (commandWithOrderedScripts as any).addDefaultValuesToProperties({}, mockFile, 'book');
 
       // Scripts should be executed in order: author (1), title (2), date (3)
-      expect(executionOrder).toEqual(['author', 'title', 'date']);
+      expect(executionOrder).toEqual(['author', 'title']);
       expect(result.author).toBe('second');
       expect(result.title).toBe('first');
-      expect(result.date).toBe('third');
+      expect(result).not.toHaveProperty('date'); // date script not executed
     });
 
     test('should handle scripts without order specification', async () => {
@@ -351,7 +355,7 @@ Content here`;
       const result = await (commandWithMixedOrder as any).addDefaultValuesToProperties({}, mockFile, 'book');
 
       // Scripts with order should come first, then scripts without order
-      expect(executionOrder).toEqual(['title', 'date', 'author']);
+      expect(executionOrder).toEqual(['title', 'author']);
     });
   });
 


### PR DESCRIPTION
/fix #9 
Enhance the testing coverage for the MetadataMenuAdapter by adding multiple test cases for the getFileClassAndAncestorsFields method.

- Updated logic to ensure property scripts are only executed on properties that are part of the fileClass or its ancestors.
- Skipped execution for properties not defined in the fileClass or ancestor fields.
- This avoids unnecessary or erroneous script runs on unrelated frontmatter properties.
- 📦 Added tests in src/externalApi/MetadataMenuAdapter.test.ts
  - Validates fields for fileClass and its ancestors using Map and object structures.
  - Ensures correct behavior when no ancestors are present.
  - Checks exception handling for non-existent fileClass.
  - Confirms empty array return when no fields or ancestors are found.
- 🔧 Refactored getFileClassAndAncestorsFields method in MetadataMenuAdapter.ts
  - Simplified field retrieval logic for better maintainability and clarity.
  - Improved handling of ancestor fields to streamline the process.